### PR TITLE
Fixed path issues that arises when calling maps grid4x4 and arterial4x4

### DIFF
--- a/resco_benchmark/multi_signal.py
+++ b/resco_benchmark/multi_signal.py
@@ -31,9 +31,14 @@ class MultiSignal(gym.Env):
 
         # Run some steps in the simulation with default light configurations to detect phases
         if self.route is not None:
+            if 'grid4x4' in self.route:
+                self.route += '/grid4x4'
+            elif 'arterial4x4' in self.route:
+                self.route += '/arterial4x4'
             sumo_cmd = [sumolib.checkBinary('sumo'), '-n', net, '-r', self.route + '_1.rou.xml', '--no-warnings', 'True']
         else:
             sumo_cmd = [sumolib.checkBinary('sumo'), '-c', net, '--no-warnings', 'True']
+        print('[DEBUG]:', sumo_cmd)
         if self.libsumo:
             traci.start(sumo_cmd)
             self.sumo = traci


### PR DESCRIPTION
When calling the `main.py` file for environments `grid4x4` or `arterial4x4`, exceptions occur due to path mismatches.